### PR TITLE
Restore previous formatting to generated parser code

### DIFF
--- a/src/neotoma_parse.erl
+++ b/src/neotoma_parse.erl
@@ -140,7 +140,7 @@ parse(Input) when is_binary(Input) ->
   ["'",Symbol,"'","(Input, Index) ->\n  ",
         "p(Input, Index, '",Symbol,"', fun(I,D) -> (",
         lists:nth(4, Tail),
-        ")(I,D) end, fun(", TransformArgs, ") ->",Transform," end)."]
+        ")(I,D) end, fun(", TransformArgs, ") -> ",Transform," end)."]
  end).
 
 'parsing_expression'(Input, Index) ->


### PR DESCRIPTION
In 03a316e8dad2a33783760316809a9e3f719ac3d6, the following change was
made that removed a space after `->`:

```
-        ")(I,D) end, fun(Node, Idx) -> ",Transform," end)."]
+        ")(I,D) end, fun(", TransformArgs, ") ->",Transform," end)."]
```

The previous behavior is more idiomatic for human readers. Restoring
the previous behavior makes it easier to review diffs of generated
parsers when verifying changes.
