### PR TITLE
Added eqc_cover parse transform.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{erl_opts, [debug_info, warn_export_vars, warnings_as_errors]}.
+{erl_opts, [{parse_transform, eqc_cover}, debug_info, warn_export_vars, warnings_as_errors]}.
 {escript_incl_apps, []}.
 {eunit_opts, [no_tty, {report, {eunit_progress, [profile, colored]}}]}.
 {deps, [{eunit_formatters, ".*", {git, "git://github.com/seancribbs/eunit_formatters.git", "master"}}]}.


### PR DESCRIPTION
This should enable the coverage information on QuickCheck-CI.
