### PR TITLE
Fix/travis erlang versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ language: erlang
 notifications:
   disabled: true
 otp_release:
+  - 17.0
+  - 17.3
+  - 17.4
+  - R16B02
+  - R16B01
+  - R16B
   - R15B02
   - R15B01
   - R15B
-  - R14B04
-  - R14B03
-  - R14B02

--- a/README.textile
+++ b/README.textile
@@ -1,5 +1,7 @@
 h1. Neotoma
 
+!https://travis-ci.org/seancribbs/neotoma.svg?branch=master!:https://travis-ci.org/seancribbs/neotoma
+
 h2. About
 
 Neotoma is a packrat parser-generator for Erlang for Parsing Expression Grammars (PEGs).


### PR DESCRIPTION
Looks like travis.yml is outdated, I think it better to support new releases then old ones, so I added 17 and removed broken R14.
