### PR TITLE
Make escript self-contained wrt requiring header

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,6 @@
 {erl_opts, [debug_info, warn_export_vars]}.
 {xref_checks, [undefined_function_calls]}.
 {eunit_opts, [verbose]}.
+{escript_incl_extra, [{"priv/peg_includes.hrl", "."}]}.
 
 {plugins, [rebar3_hex]}.


### PR DESCRIPTION
The peg_includes.hrl is contained in the escript archive to obviate the
need for checking a problem ridden priv_dir.