### PR TITLE
fix "param_missing,registered" error with exrm release

### DIFF
--- a/src/neotoma.app.src
+++ b/src/neotoma.app.src
@@ -2,6 +2,7 @@
  [
   {description, "PEG/Packrat toolkit and parser-generator."},
   {vsn, "1.7.3"},
+  {registered, []},
   {applications, [kernel, stdlib]},
   {contributors, ["Sean Cribbs"]},
   {licenses, ["MIT"]},


### PR DESCRIPTION
Starting off with an Ubuntu 14.04 Docker Image, Erlang 18.2, erts-7.2 and exrm 1.0.3 there is a problem when running ```mix release``` (partially below). The param "registered" needs to be defined when using systools. Oddly, the problem does not occur on a quite similar scenario on OSX, where creating the release is successful. Provided pull request is a fix.

```
===> Running provider release
===> Including Erts from /usr/lib/erlang
===> Provider (release) failed with: {error,
                                      {rlx_prv_assembler,
                                       {release_script_generation_error,
                                        systools_make,
                                        [{error_reading,
                                          {neotoma,
                                           {{missing_param,registered},
                                            {application,neotoma,
                                             [{description,
                                               "PEG/Packrat toolkit and parser-generator."},
                                              {vsn,"1.7.3"},
                                              {applications,[kernel,stdlib]},
                                              {contributors,["Sean Cribbs"]},
                                              {licenses,["MIT"]},
                                              {links,
                                               [{"Github",
                                                 "https://github.com/seancribbs/neotoma"}]},
                                              {modules,
                                               [neotoma,
                                                neotoma_parse]}]}}}}]}}}

```