### PR TITLE
Add case insensitive string using i suffix

### DIFF
--- a/priv/neotoma_parse.peg
+++ b/priv/neotoma_parse.peg
@@ -146,7 +146,7 @@ nonterminal <- alpha_char alphanumeric_char*
   {nonterminal, Symbol}
 `;
 
-terminal <- regexp_string / quoted_string / character_class / anything_symbol ~;
+terminal <- regexp_string / case_insensitive_string / quoted_string / character_class / anything_symbol ~;
 
 regexp_string <- '#' string:(!'#' ('\\#' / .))+ '#'
 `
@@ -170,6 +170,15 @@ quoted_string <- single_quoted_string / double_quoted_string
 double_quoted_string <- '"' string:(!'"' ("\\\\" / '\\"' / .))* '"' ~;
 
 single_quoted_string <- "'" string:(!"'" ("\\\\" / "\\'" / .))* "'" ~;
+
+case_insensitive_string <- target:(double_quoted_string / single_quoted_string) 'i' 
+`
+  used_combinator(p_case_insensitive),
+  Str = string:lowercase(proplists:get_value(string, proplists:get_value(target, Node))),
+  lists:flatten(["p_case_insensitive(<<\"", 
+    escape_string(unicode:characters_to_list(Str)),
+    "\">>)"])
+`;
 
 character_class <- '[' characters:(!']' ('\\\\' . / !'\\\\' .))+ ']'
 `

--- a/priv/peg_includes.hrl
+++ b/priv/peg_includes.hrl
@@ -192,6 +192,22 @@ p_string(S) ->
     end.
 -endif.
 
+-ifdef(p_case_insensitive).
+-spec p_case_insensitive(binary()) -> parse_fun().
+p_case_insensitive(S) ->
+    Length = erlang:byte_size(S),
+    SLower = string:lowercase(S),
+    fun(Input, Index) ->
+      try
+          <<Sc:Length/binary, Rest/binary>> = Input,
+          SLower = string:lowercase(Sc),
+          {SLower, Rest, p_advance_index(S, Index)}
+      catch
+          error:{badmatch,_} -> {fail, {expected, {string, S}, Index}}
+      end
+    end.
+-endif.
+
 -ifdef(p_anything).
 -spec p_anything() -> parse_fun().
 p_anything() ->

--- a/src/neotoma.erl
+++ b/src/neotoma.erl
@@ -5,7 +5,7 @@
 
 -define(ALL_COMBINATORS, [p_eof, p_optional, p_not, p_assert, p_seq,
         p_choose, p_zero_or_more, p_one_or_more, p_label, p_scan,
-        p_string, p_anything, p_charclass, p_regexp, line, column]).
+        p_string, p_case_insensitive, p_anything, p_charclass, p_regexp, line, column]).
 
 -type option() :: {module, atom()} | {output, file:filename()} |  {transform_module, atom()} |
                   {neotoma_priv_dir, file:filename()}.

--- a/test/neotoma_peg.erl
+++ b/test/neotoma_peg.erl
@@ -16,6 +16,7 @@
 -define(p_label,true).
 -define(p_scan,true).
 -define(p_string,true).
+-define(p_case_insensitive,true).
 -define(p_anything,true).
 -define(p_charclass,true).
 -define(p_regexp,true).
@@ -25,6 +26,6 @@
 -export([p/5]).
 -export([setup_memo/0, release_memo/0]).
 
--export([p_eof/0, p_optional/1, p_not/1, p_assert/1, p_seq/1, p_choose/1, p_zero_or_more/1, p_one_or_more/1, p_label/2, p_string/1, p_anything/0, p_charclass/1, p_regexp/1, line/1, column/1]).
+-export([p_eof/0, p_optional/1, p_not/1, p_assert/1, p_seq/1, p_choose/1, p_zero_or_more/1, p_one_or_more/1, p_label/2, p_string/1, p_case_insensitive/1, p_anything/0, p_charclass/1, p_regexp/1, line/1, column/1]).
 
 -include("priv/peg_includes.hrl").

--- a/test/test_combinators.erl
+++ b/test/test_combinators.erl
@@ -72,6 +72,12 @@ string_test_() ->
      ?_assertEqual({fail,{expected, {string, <<"abc">>}, ?STARTINDEX}}, (neotoma_peg:p_string(<<"abc">>))(<<"defabc">>,?STARTINDEX))
     ].
 
+case_insensitive_test_() ->
+    [
+      ?_assertEqual({<<"abc">>, <<"def">>, {{line,1}, {column, 4}}}, (neotoma_peg:p_case_insensitive(<<"abc">>))(<<"aBCdef">>,?STARTINDEX)),
+      ?_assertEqual({fail,{expected, {string, <<"abc">>}, ?STARTINDEX}}, (neotoma_peg:p_case_insensitive(<<"abc">>))(<<"defabc">>,?STARTINDEX))
+    ].
+
 anything_test_() ->
     [
      ?_assertEqual({<<"a">>,<<"bcde">>,{{line,1},{column,2}}}, (neotoma_peg:p_anything())(<<"abcde">>,?STARTINDEX)),

--- a/test/test_parse.erl
+++ b/test/test_parse.erl
@@ -17,3 +17,18 @@ parser_test() ->
         _:_  -> ?assert(false)
     end.
 
+case_insensitive_test() ->
+    % so we don't have to copy test.peg to .eunit
+    Data = "rule <- \"caSe\"i;",
+    file:write_file("test_parser.peg", io_lib:fwrite("~s\n", [Data])),
+    neotoma:file("test_parser.peg"),
+    compile:file("test_parser.erl", []),
+    try 
+        TestString =  "caSE",
+        Result = test_parser:parse(TestString),
+        ?assertEqual(4, length(Result)),
+        StringResult = lists:flatten(io_lib:format("~ts", [Result])),
+        ?assertEqual(TestString, StringResult)
+    catch
+        _:_  -> ?assert(false)
+    end.


### PR DESCRIPTION
Allow writing "str"i, "STR"i or 'str'i and it will match all case combinations
of str: str, Str, STr, STR, sTr, and so on.
This makes it unnecessary to write a rule like:
  str <- [Ss] [Tt] [Rr] ~;
This simplifies writing parsers for languages where the keywords are
case insensitive.